### PR TITLE
ECO-1243: [Computop]OMS Improvement Incorrect state machine for Paydi…

### DIFF
--- a/config/Zed/Oms/ComputopPaydirekt01.xml
+++ b/config/Zed/Oms/ComputopPaydirekt01.xml
@@ -47,7 +47,7 @@
             </transition>
 
             <transition>
-                <source>new</source>
+                <source>authorized</source>
                 <target>capture failed</target>
                 <event>capture</event>
             </transition>


### PR DESCRIPTION
It was necessary to make path to the "Capture failed" state starting not from the initial state "New". 

