### PR TITLE
ECO-2522: added neccessary data to request to make it valid for easycredit

### DIFF
--- a/src/SprykerEco/Shared/Computop/Transfer/computop.transfer.xml
+++ b/src/SprykerEco/Shared/Computop/Transfer/computop.transfer.xml
@@ -37,6 +37,10 @@
         <property name="clientIp" type="string" />
         <property name="finishAuth" type="string" />
         <property name="shippingZip" type="string" />
+        <property name="shippingCity" type="string" />
+        <property name="shippingStreetNumber" type="string" />
+        <property name="shippingStreet" type="string" />
+        <property name="shippingCountryCode" type="string" />
         <property name="payNowInitResponse" type="ComputopPayNowInitResponse"/>
     </transfer>
 
@@ -85,6 +89,10 @@
         <property name="clientIp" type="string" />
         <property name="finishAuth" type="string" />
         <property name="shippingZip" type="string" />
+        <property name="shippingCity" type="string" />
+        <property name="shippingStreetNumber" type="string" />
+        <property name="shippingStreet" type="string" />
+        <property name="shippingCountryCode" type="string" />
         <property name="creditCardInitResponse" type="ComputopCreditCardInitResponse"/>
     </transfer>
 
@@ -110,6 +118,10 @@
         <property name="len" type="int" />
         <property name="url" type="string" />
         <property name="shippingZip" type="string" />
+        <property name="shippingCity" type="string" />
+        <property name="shippingStreetNumber" type="string" />
+        <property name="shippingStreet" type="string" />
+        <property name="shippingCountryCode" type="string" />
         <property name="directDebitInitResponse" type="ComputopDirectDebitInitResponse"/>
     </transfer>
 
@@ -162,6 +174,10 @@
         <property name="len" type="int" />
         <property name="url" type="string" />
         <property name="shippingZip" type="string" />
+        <property name="shippingCity" type="string" />
+        <property name="shippingStreetNumber" type="string" />
+        <property name="shippingStreet" type="string" />
+        <property name="shippingCountryCode" type="string" />
         <property name="payPalInitResponse" type="ComputopPayPalInitResponse"/>
     </transfer>
 
@@ -186,6 +202,10 @@
         <property name="len" type="int" />
         <property name="url" type="string" />
         <property name="shippingZip" type="string" />
+        <property name="shippingCity" type="string" />
+        <property name="shippingStreetNumber" type="string" />
+        <property name="shippingStreet" type="string" />
+        <property name="shippingCountryCode" type="string" />
         <property name="sofortInitResponse" type="ComputopSofortInitResponse"/>
     </transfer>
 
@@ -212,6 +232,8 @@
         <property name="shippingZip" type="string" />
         <property name="shippingCity" type="string" />
         <property name="shippingCountryCode" type="string" />
+        <property name="shippingStreetNumber" type="string" />
+        <property name="shippingStreet" type="string" />
         <property name="shoppingBasketAmount" type="string" />
         <property name="articleList" type="string" />
         <property name="email" type="string" />
@@ -249,6 +271,10 @@
         <property name="len" type="int" />
         <property name="url" type="string" />
         <property name="shippingZip" type="string" />
+        <property name="shippingCity" type="string" />
+        <property name="shippingStreetNumber" type="string" />
+        <property name="shippingStreet" type="string" />
+        <property name="shippingCountryCode" type="string" />
         <property name="idealInitResponse" type="ComputopIdealInitResponse"/>
     </transfer>
 
@@ -274,6 +300,10 @@
         <property name="len" type="int" />
         <property name="url" type="string" />
         <property name="shippingZip" type="string" />
+        <property name="shippingCity" type="string" />
+        <property name="shippingStreetNumber" type="string" />
+        <property name="shippingStreet" type="string" />
+        <property name="shippingCountryCode" type="string" />
         <property name="easyCreditInitResponse" type="ComputopEasyCreditInitResponse"/>
         <property name="easyCreditStatusResponse" type="ComputopApiEasyCreditStatusResponse"/>
 

--- a/src/SprykerEco/Shared/Computop/Transfer/computop.transfer.xml
+++ b/src/SprykerEco/Shared/Computop/Transfer/computop.transfer.xml
@@ -37,10 +37,6 @@
         <property name="clientIp" type="string" />
         <property name="finishAuth" type="string" />
         <property name="shippingZip" type="string" />
-        <property name="shippingCity" type="string" />
-        <property name="shippingStreetNumber" type="string" />
-        <property name="shippingStreet" type="string" />
-        <property name="shippingCountryCode" type="string" />
         <property name="payNowInitResponse" type="ComputopPayNowInitResponse"/>
     </transfer>
 
@@ -89,10 +85,6 @@
         <property name="clientIp" type="string" />
         <property name="finishAuth" type="string" />
         <property name="shippingZip" type="string" />
-        <property name="shippingCity" type="string" />
-        <property name="shippingStreetNumber" type="string" />
-        <property name="shippingStreet" type="string" />
-        <property name="shippingCountryCode" type="string" />
         <property name="creditCardInitResponse" type="ComputopCreditCardInitResponse"/>
     </transfer>
 
@@ -118,10 +110,6 @@
         <property name="len" type="int" />
         <property name="url" type="string" />
         <property name="shippingZip" type="string" />
-        <property name="shippingCity" type="string" />
-        <property name="shippingStreetNumber" type="string" />
-        <property name="shippingStreet" type="string" />
-        <property name="shippingCountryCode" type="string" />
         <property name="directDebitInitResponse" type="ComputopDirectDebitInitResponse"/>
     </transfer>
 
@@ -174,10 +162,6 @@
         <property name="len" type="int" />
         <property name="url" type="string" />
         <property name="shippingZip" type="string" />
-        <property name="shippingCity" type="string" />
-        <property name="shippingStreetNumber" type="string" />
-        <property name="shippingStreet" type="string" />
-        <property name="shippingCountryCode" type="string" />
         <property name="payPalInitResponse" type="ComputopPayPalInitResponse"/>
     </transfer>
 
@@ -202,10 +186,6 @@
         <property name="len" type="int" />
         <property name="url" type="string" />
         <property name="shippingZip" type="string" />
-        <property name="shippingCity" type="string" />
-        <property name="shippingStreetNumber" type="string" />
-        <property name="shippingStreet" type="string" />
-        <property name="shippingCountryCode" type="string" />
         <property name="sofortInitResponse" type="ComputopSofortInitResponse"/>
     </transfer>
 
@@ -232,8 +212,6 @@
         <property name="shippingZip" type="string" />
         <property name="shippingCity" type="string" />
         <property name="shippingCountryCode" type="string" />
-        <property name="shippingStreetNumber" type="string" />
-        <property name="shippingStreet" type="string" />
         <property name="shoppingBasketAmount" type="string" />
         <property name="articleList" type="string" />
         <property name="email" type="string" />
@@ -271,10 +249,6 @@
         <property name="len" type="int" />
         <property name="url" type="string" />
         <property name="shippingZip" type="string" />
-        <property name="shippingCity" type="string" />
-        <property name="shippingStreetNumber" type="string" />
-        <property name="shippingStreet" type="string" />
-        <property name="shippingCountryCode" type="string" />
         <property name="idealInitResponse" type="ComputopIdealInitResponse"/>
     </transfer>
 

--- a/src/SprykerEco/Yves/Computop/Mapper/Init/AbstractMapper.php
+++ b/src/SprykerEco/Yves/Computop/Mapper/Init/AbstractMapper.php
@@ -8,7 +8,6 @@
 namespace SprykerEco\Yves\Computop\Mapper\Init;
 
 use Generated\Shared\Transfer\ComputopApiRequestTransfer;
-use Generated\Shared\Transfer\ComputopEasyCreditPaymentTransfer;
 use Generated\Shared\Transfer\QuoteTransfer;
 use Silex\Application;
 use Spryker\Shared\Kernel\Transfer\TransferInterface;
@@ -88,14 +87,7 @@ abstract class AbstractMapper implements MapperInterface
         $computopPaymentTransfer->setUrlFailure(
             $this->getAbsoluteUrl($this->application->path(ComputopControllerProvider::FAILURE_PATH_NAME))
         );
-
-        $addressData = $this->getAddressData($quoteTransfer);
-
-        $computopPaymentTransfer->setShippingZip($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_ZIP]);
-        $computopPaymentTransfer->setShippingCity($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_CITY]);
-        $computopPaymentTransfer->setShippingStreet($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_STREET]);
-        $computopPaymentTransfer->setShippingStreetNumber($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_STREET_NUMBER]);
-        $computopPaymentTransfer->setShippingCountryCode($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_COUNTRY_CODE]);
+        $computopPaymentTransfer->setShippingZip($this->getZipCode($quoteTransfer));
 
         return $computopPaymentTransfer;
     }
@@ -197,18 +189,14 @@ abstract class AbstractMapper implements MapperInterface
     /**
      * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
      *
-     * @return array
+     * @return string
      */
-    protected function getAddressData(QuoteTransfer $quoteTransfer): array
+    protected function getZipCode(QuoteTransfer $quoteTransfer): string
     {
-        $addressTransfer = $quoteTransfer->getBillingSameAsShipping() ? $quoteTransfer->getBillingAddress() : $quoteTransfer->getShippingAddress();
+        if ($quoteTransfer->getBillingSameAsShipping()) {
+            return $quoteTransfer->getBillingAddress()->getZipCode();
+        }
 
-        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_ZIP] = $addressTransfer->getZipCode();
-        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_CITY] = $addressTransfer->getCity();
-        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_STREET] = $addressTransfer->getAddress1();
-        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_STREET_NUMBER] = $addressTransfer->getAddress2();
-        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_COUNTRY_CODE] = $addressTransfer->getIso2Code();
-
-        return $addressData;
+        return $quoteTransfer->getShippingAddress()->getZipCode();
     }
 }

--- a/src/SprykerEco/Yves/Computop/Mapper/Init/AbstractMapper.php
+++ b/src/SprykerEco/Yves/Computop/Mapper/Init/AbstractMapper.php
@@ -8,6 +8,7 @@
 namespace SprykerEco\Yves\Computop\Mapper\Init;
 
 use Generated\Shared\Transfer\ComputopApiRequestTransfer;
+use Generated\Shared\Transfer\ComputopEasyCreditPaymentTransfer;
 use Generated\Shared\Transfer\QuoteTransfer;
 use Silex\Application;
 use Spryker\Shared\Kernel\Transfer\TransferInterface;
@@ -87,7 +88,14 @@ abstract class AbstractMapper implements MapperInterface
         $computopPaymentTransfer->setUrlFailure(
             $this->getAbsoluteUrl($this->application->path(ComputopControllerProvider::FAILURE_PATH_NAME))
         );
-        $computopPaymentTransfer->setShippingZip($this->getZipCode($quoteTransfer));
+
+        $addressData = $this->getAddressData($quoteTransfer);
+
+        $computopPaymentTransfer->setShippingZip($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_ZIP]);
+        $computopPaymentTransfer->setShippingCity($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_CITY]);
+        $computopPaymentTransfer->setShippingStreet($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_STREET]);
+        $computopPaymentTransfer->setShippingStreetNumber($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_STREET_NUMBER]);
+        $computopPaymentTransfer->setShippingCountryCode($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_COUNTRY_CODE]);
 
         return $computopPaymentTransfer;
     }
@@ -189,14 +197,18 @@ abstract class AbstractMapper implements MapperInterface
     /**
      * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
      *
-     * @return string
+     * @return array
      */
-    protected function getZipCode(QuoteTransfer $quoteTransfer): string
+    protected function getAddressData(QuoteTransfer $quoteTransfer): array
     {
-        if ($quoteTransfer->getBillingSameAsShipping()) {
-            return $quoteTransfer->getBillingAddress()->getZipCode();
-        }
+        $addressTransfer = $quoteTransfer->getBillingSameAsShipping() ? $quoteTransfer->getBillingAddress() : $quoteTransfer->getShippingAddress();
 
-        return $quoteTransfer->getShippingAddress()->getZipCode();
+        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_ZIP] = $addressTransfer->getZipCode();
+        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_CITY] = $addressTransfer->getCity();
+        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_STREET] = $addressTransfer->getAddress1();
+        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_STREET_NUMBER] = $addressTransfer->getAddress2();
+        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_COUNTRY_CODE] = $addressTransfer->getIso2Code();
+
+        return $addressData;
     }
 }

--- a/src/SprykerEco/Yves/Computop/Mapper/Init/PostPlace/EasyCreditMapper.php
+++ b/src/SprykerEco/Yves/Computop/Mapper/Init/PostPlace/EasyCreditMapper.php
@@ -90,6 +90,10 @@ class EasyCreditMapper extends AbstractMapper
         $dataSubArray[ComputopApiConfig::ETI_ID] = $this->config->getEtiId();
         $dataSubArray[ComputopApiConfig::IP_ADDRESS] = $cardPaymentTransfer->getClientIp();
         $dataSubArray[ComputopApiConfig::SHIPPING_ZIP] = $cardPaymentTransfer->getShippingZip();
+        $dataSubArray[ComputopApiConfig::SHIPPING_CITY] = $cardPaymentTransfer->getShippingCity();
+        $dataSubArray[ComputopApiConfig::SHIPPING_COUNTRY_CODE] = $cardPaymentTransfer->getShippingCountryCode();
+        $dataSubArray[ComputopApiConfig::SHIPPING_STREET] = $cardPaymentTransfer->getShippingStreet();
+        $dataSubArray[ComputopApiConfig::SHIPPING_STREET_NUMBER] = $cardPaymentTransfer->getShippingStreetNumber();
 
         return $dataSubArray;
     }

--- a/src/SprykerEco/Yves/Computop/Mapper/Init/PostPlace/EasyCreditMapper.php
+++ b/src/SprykerEco/Yves/Computop/Mapper/Init/PostPlace/EasyCreditMapper.php
@@ -25,6 +25,9 @@ class EasyCreditMapper extends AbstractMapper
         /** @var \Generated\Shared\Transfer\ComputopEasyCreditPaymentTransfer $computopPaymentTransfer */
         $computopPaymentTransfer = parent::createComputopPaymentTransfer($quoteTransfer);
 
+        $addressData = $this->getAdditionalAddressData($quoteTransfer);
+        $computopPaymentTransfer = $this->mapAddressDataToEasyCreditPayment($addressData, $computopPaymentTransfer);
+
         $computopPaymentTransfer->setUrlNotify(
             $this->getAbsoluteUrl($this->application->path(ComputopControllerProvider::NOTIFY_PATH_NAME))
         );
@@ -96,5 +99,41 @@ class EasyCreditMapper extends AbstractMapper
         $dataSubArray[ComputopApiConfig::SHIPPING_STREET_NUMBER] = $cardPaymentTransfer->getShippingStreetNumber();
 
         return $dataSubArray;
+    }
+
+    /**
+     * @param array $addressData
+     * @param \Generated\Shared\Transfer\ComputopEasyCreditPaymentTransfer $computopEasyCreditPaymentTransfer
+     *
+     * @return \Generated\Shared\Transfer\ComputopEasyCreditPaymentTransfer
+     */
+    protected function mapAddressDataToEasyCreditPayment(
+        array $addressData,
+        ComputopEasyCreditPaymentTransfer $computopEasyCreditPaymentTransfer
+    ): ComputopEasyCreditPaymentTransfer {
+
+        $computopEasyCreditPaymentTransfer->setShippingCity($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_CITY]);
+        $computopEasyCreditPaymentTransfer->setShippingStreet($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_STREET]);
+        $computopEasyCreditPaymentTransfer->setShippingStreetNumber($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_STREET_NUMBER]);
+        $computopEasyCreditPaymentTransfer->setShippingCountryCode($addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_COUNTRY_CODE]);
+
+        return $computopEasyCreditPaymentTransfer;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     *
+     * @return array
+     */
+    protected function getAdditionalAddressData(QuoteTransfer $quoteTransfer): array
+    {
+        $addressTransfer = $quoteTransfer->getBillingSameAsShipping() ? $quoteTransfer->getBillingAddress() : $quoteTransfer->getShippingAddress();
+
+        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_CITY] = $addressTransfer->getCity();
+        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_STREET] = $addressTransfer->getAddress1();
+        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_STREET_NUMBER] = $addressTransfer->getAddress2();
+        $addressData[ComputopEasyCreditPaymentTransfer::SHIPPING_COUNTRY_CODE] = $addressTransfer->getIso2Code();
+
+        return $addressData;
     }
 }


### PR DESCRIPTION
- Developer(s): @Ruslan05

- Ticket: https://spryker.atlassian.net/browse/ECO-2521

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Computop              | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Computop

##### Change log

Improvements

- Added `shippingCity`, `shippingStreetNumber `, `shippingStreet `  and `shippingCountryCode ` properties to `ComputopEasyCreditPayment `.
- Adjusted `SprykerEco\Yves\Computop\Mapper\Init\PostPlace\ EasyCreditMapper ` to send additional data mentioned in transfer.

