### PR TITLE
CC-16599 Added missing PayPal Express config in Computop module

### DIFF
--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -41,6 +41,8 @@ $config[ComputopApiConstants::CAPTURE_ACTION] = 'https://www.computop-paygate.co
 $config[ComputopApiConstants::REVERSE_ACTION] = 'https://www.computop-paygate.com/reverse.aspx';
 $config[ComputopApiConstants::INQUIRE_ACTION] = 'https://www.computop-paygate.com/inquire.aspx';
 $config[ComputopApiConstants::REFUND_ACTION] = 'https://www.computop-paygate.com/credit.aspx';
+$config[ComputopApiConstants::PAYPAL_EXPRESS_PREPARE_ACTION] = 'https://www.computop-paygate.com/ExternalServices/paypalorders.aspx';
+$config[ComputopApiConstants::PAYPAL_EXPRESS_COMPLETE_ACTION] = 'https://www.computop-paygate.com/paypalComplete.aspx';
 
 $config[ComputopApiConstants::RESPONSE_MAC_REQUIRED] = [
     ComputopConfig::INIT_METHOD, // Todo: add methods in case of Paygate form connection


### PR DESCRIPTION
- Developer(s): @kkicheglovspryker

- Ticket: https://spryker.atlassian.net/browse/CC-16599

- Release Group: https://release.spryker.com/release-groups/view/4051

- PR Overview: https://release.spryker.com/release/pull-request-eco/Computop/46

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Computop            | patch {skip}                 |   |

